### PR TITLE
:add: ergoauth

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -150,6 +150,9 @@ async def ergoauth_verify(request_id: str, authResponse: ErgoAuthResponse, db=De
             cache.invalidate(f"ergoauth_signing_request_{request_id}")
             return { "status": "ok" }
         else:
+            # notify frontend on failure
+            permissions = "login_error"
+            await connection_manager.send_personal_message(request_id, {"permissions": permissions})
             return { "status": "failed" }
     except Exception as e:
         return JSONResponse(status_code=400, content=f"ERR::login::{str(e)}")

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from starlette.responses import JSONResponse
 
 from db.crud.users import blacklist_token
+from db.schemas.users import UserSignUp, User
 from db.session import get_db
 
 from core import security
@@ -11,8 +12,18 @@ from core.auth import authenticate_user, get_current_active_user, sign_up_new_us
 
 auth_router = r = APIRouter()
 
+# TODO:
+# 1. POST /login
+#    - generate siging_request, return signing_request url
+# 2. POST /signing_request/{request_id}
+#    - return a ergoauth signing_request from redis
+# 3. POST /token used for ergoauth login for nautilus
+#    - verify address, signed_message and proof directly and return a jwt_token 
+# 4. WebSocket /ws/{request_id}
+#    - Frontend listens to this websocket for approval on mobile app
 
-@r.post("/token/admin")
+
+@r.post("/token/admin", name="auth:admin-login")
 async def login_admin(
     db=Depends(get_db), form_data: OAuth2PasswordRequestForm = Depends()
 ):
@@ -47,7 +58,21 @@ async def login_admin(
         return JSONResponse(status_code=400, content=f"ERR::login::{str(e)}")
 
 
-@r.post("/signup/admin")
+@r.post("/signup", response_model=User, response_model_exclude_none=True, name="auth:signup")
+async def signup(
+    user: UserSignUp,
+    db=Depends(get_db)
+):
+    try:
+        user = sign_up_new_user(db, user.alias, "__ergoauth_default", user.profile_img_url, user.primary_wallet_address)
+        if not user:
+            return JSONResponse(status_code=status.HTTP_409_CONFLICT, content="User already exists")
+        return user
+    except Exception as e:
+        return JSONResponse(status_code=400, content=f"ERR::signup::{str(e)}")
+
+
+@r.post("/signup/admin", name="auth:admin-signup")
 async def signup_admin(
     db=Depends(get_db), form_data: OAuth2PasswordRequestForm = Depends()
 ):
@@ -83,7 +108,7 @@ async def signup_admin(
         return JSONResponse(status_code=400, content=f"ERR::signup::{str(e)}")
 
 
-@r.post("/logout")
+@r.post("/logout", name="auth:logout")
 async def logout(db=Depends(get_db), token: str = Depends(security.oauth2_scheme), current_user=Depends(get_current_active_user)):
     try:
         return blacklist_token(db, token)

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -12,8 +12,8 @@ from core.auth import authenticate_user, get_current_active_user, sign_up_new_us
 auth_router = r = APIRouter()
 
 
-@r.post("/token")
-async def login(
+@r.post("/token/admin")
+async def login_admin(
     db=Depends(get_db), form_data: OAuth2PasswordRequestForm = Depends()
 ):
     try:
@@ -31,7 +31,11 @@ async def login(
         if user.is_superuser:
             permissions = "admin"
         else:
-            permissions = "user"
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Admin only endpoint",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
         access_token = security.create_access_token(
             data={"sub": user.alias, "permissions": permissions},
             expires_delta=access_token_expires,
@@ -43,8 +47,8 @@ async def login(
         return JSONResponse(status_code=400, content=f"ERR::login::{str(e)}")
 
 
-@r.post("/signup")
-async def signup(
+@r.post("/signup/admin")
+async def signup_admin(
     db=Depends(get_db), form_data: OAuth2PasswordRequestForm = Depends()
 ):
     try:
@@ -62,7 +66,11 @@ async def signup(
         if user.is_superuser:
             permissions = "admin"
         else:
-            permissions = "user"
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Admin only endpoint",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
         access_token = security.create_access_token(
             data={"sub": user.alias, "permissions": permissions},
             expires_delta=access_token_expires,

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -102,28 +102,6 @@ async def user_edit(
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'{str(e)}')
 
 
-@r.put(
-    "/{user_id}/update", response_model=User, response_model_exclude_none=True, name="users:update-details"
-)
-async def user_edit(
-    request: Request,
-    user_id: int,
-    user: UserEdit,
-    db=Depends(get_db),
-    current_user=Depends(get_current_active_user),
-):
-    """
-    Update user self
-    """
-    try:
-        if (user_id == current_user.id and user.is_active == current_user.is_active and user.is_superuser == current_user.is_superuser):
-            return edit_user(db, user_id, user)
-        else:
-            return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=f'Not authorized to change other user data fields')
-    except Exception as e:
-        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'{str(e)}')
-
-
 @r.delete(
     "/{user_id}", response_model=User, response_model_exclude_none=True, name="users:delete"
 )

--- a/app/api/util.py
+++ b/app/api/util.py
@@ -47,7 +47,7 @@ class InvalidateCacheRequest(BaseModel):
     key: str
 
 
-@r.post("/force_invalidate_cache", name="cache:invalidate")
+@r.post("/force_invalidate_cache", name="util:cache-invalidate")
 def forceInvalidateCache(req: InvalidateCacheRequest, current_user=Depends(get_current_active_superuser)):
     try:
         return {'status': 'success', 'detail': cache.invalidate(req.key)}

--- a/app/api/util.py
+++ b/app/api/util.py
@@ -7,7 +7,7 @@ from fastapi.param_functions import File
 from pydantic import BaseModel
 from starlette.responses import JSONResponse
 from config import Config, Network  # api specific config
-from core.auth import get_current_active_user
+from core.auth import get_current_active_user, get_current_active_superuser
 from cache.cache import cache
 from aws.s3 import S3
 
@@ -48,7 +48,7 @@ class InvalidateCacheRequest(BaseModel):
 
 
 @r.post("/force_invalidate_cache", name="cache:invalidate")
-def forceInvalidateCache(req: InvalidateCacheRequest, current_user=Depends(get_current_active_user)):
+def forceInvalidateCache(req: InvalidateCacheRequest, current_user=Depends(get_current_active_superuser)):
     try:
         return {'status': 'success', 'detail': cache.invalidate(req.key)}
     except Exception as e:

--- a/app/config.py
+++ b/app/config.py
@@ -50,6 +50,7 @@ Config = {
         's3Bucket': os.getenv("S3_BUCKET"),
         's3Key': os.getenv("S3_KEY"),
         'jwtSecret': os.getenv("JWT_SECRET_KEY"),
+        'ergoAuthSeed': os.getenv("ERGOAUTH_SEED"),
     }),
     'mainnet': dotdict({
         'DEBUG': False,
@@ -63,5 +64,6 @@ Config = {
         's3Bucket': os.getenv("S3_BUCKET"),
         's3Key': os.getenv("S3_KEY"),
         'jwtSecret': os.getenv("JWT_SECRET_KEY"),
+        'ergoAuthSeed': os.getenv("ERGOAUTH_SEED"),
     })
 }

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -6,7 +6,7 @@ from db.session import get_db
 from db.models import users as models
 from db.schemas import users as schemas
 from db.schemas.token import TokenData
-from db.crud.users import get_blacklisted_token, get_user_by_alias, create_user, edit_user, set_ergo_addresses_by_user_id
+from db.crud.users import get_blacklisted_token, get_user_by_alias, create_user, edit_user, set_ergo_addresses_by_user_id, get_user_by_primary_wallet_address
 from core import security
 
 
@@ -68,7 +68,11 @@ def authenticate_user(db, alias: str, password: str):
 def sign_up_new_user(db, alias: str, password: str, profile_img_url = None, primary_wallet_address = None):
     user = get_user_by_alias(db, alias)
     if user:
-        return False  # User already exists
+        return False    # User already exists
+    if primary_wallet_address:
+        user = get_user_by_primary_wallet_address(primary_wallet_address)
+        if user:
+            return False    # Address is taken?
     new_user = create_user(
         db,
         schemas.UserCreate(

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 from config import Config, Network
 CFG = Config[Network]
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/token")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/token/admin")
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 SECRET_KEY = CFG.jwtSecret

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,3 +1,5 @@
+import time
+import secrets
 import hashlib
 import jwt
 
@@ -37,3 +39,21 @@ def create_access_token(*, data: dict, expires_delta: timedelta = None):
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
+
+
+# ergoauth stuff
+
+
+def generate_verification_id() -> str:
+    # a UUID for the request and
+    # save the used sigmaBoolean and signing message. The UUID should be
+    # path variable for the reply to address and used to fetch the SigmaBoolean
+    # and signingMessage data
+    return secrets.token_urlsafe()
+
+
+def generate_signing_message() -> str:
+    # we need a message to sign. This message should be unique for our dApp,
+    # never occur twice and should not be predictable, so we use a timestring, a unique name
+    # and a random component
+    return str(secrets.token_urlsafe() + CFG.ergoAuthSeed + str(int(time.time())))

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 from config import Config, Network
 CFG = Config[Network]
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/token/admin")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/admin/token")
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 SECRET_KEY = CFG.jwtSecret

--- a/app/db/crud/users.py
+++ b/app/db/crud/users.py
@@ -24,6 +24,10 @@ def get_user_by_alias(db: Session, alias: str) -> schemas.UserBase:
     return db.query(models.User).filter(models.User.alias == alias).first()
 
 
+def get_user_by_primary_wallet_address(db: Session, primary_wallet_address):
+    return db.query(models.User, models.ErgoAddress).filter(models.User.primary_wallet_address_id == models.ErgoAddress.id).filter(models.ErgoAddress.address == primary_wallet_address).first()
+
+
 def get_users(
     db: Session, skip: int = 0, limit: int = 100
 ) -> t.List[schemas.UserOut]:

--- a/app/db/schemas/ergoauth.py
+++ b/app/db/schemas/ergoauth.py
@@ -12,6 +12,7 @@ class LoginRequestWebResponse(BaseModel):
 
 class LoginRequestMobileResponse(BaseModel):
     address: str
+    verificationId: str
     signingRequestUrl: str
 
 

--- a/app/db/schemas/ergoauth.py
+++ b/app/db/schemas/ergoauth.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel
+
+class LoginRequest(BaseModel):
+    address: str
+
+
+class LoginRequestWebResponse(BaseModel):
+    address: str
+    signingMessage: str
+    tokenUrl: str
+
+
+class LoginRequestMobileResponse(BaseModel):
+    address: str
+    signingRequestUrl: str
+
+
+class ErgoAuthRequest(BaseModel):
+    address: str
+    signingMessage: str
+    sigmaBoolean: str
+    userMessage: str = "sign this message using your wallet to approve authenticate paideia.im"
+    messageSeverity: str = "INFORMATION"
+    replyTo: str
+
+
+class ErgoAuthResponse(BaseModel):
+    signedMessage: str
+    proof: str

--- a/app/db/schemas/users.py
+++ b/app/db/schemas/users.py
@@ -24,6 +24,12 @@ class UserCreate(UserBase):
         orm_mode = True
 
 
+class UserSignUp(BaseModel):
+    alias: str
+    primary_wallet_address: str
+    profile_img_url: t.Optional[str]
+
+
 class UserEdit(UserBase):
     password: t.Optional[str] = None
 

--- a/app/db/schemas/users.py
+++ b/app/db/schemas/users.py
@@ -18,7 +18,7 @@ class UserOut(UserBase):
 
 
 class UserCreate(UserBase):
-    password: str
+    password: str = "__ergoauth_default"
 
     class Config:
         orm_mode = True

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,7 +1,8 @@
+uvicorn
 fastapi
+websockets
 python-multipart
 python-dotenv
-uvicorn
 pydantic
 requests
 psycopg2==2.9.3
@@ -16,5 +17,4 @@ pytest
 pytest-asyncio
 pytest-mock
 colorlog
-websockets
 git+https://github.com/ergo-pad/ergo-python-appkit@main

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -5,7 +5,6 @@ uvicorn
 pydantic
 requests
 psycopg2==2.9.3
-asyncpg
 databases[postgresql]
 SQLAlchemy
 sqlalchemy-utils
@@ -17,3 +16,5 @@ pytest
 pytest-asyncio
 pytest-mock
 colorlog
+websockets
+git+https://github.com/ergo-pad/ergo-python-appkit@main

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,7 +4,7 @@ python-dotenv
 uvicorn
 pydantic
 requests
-psycopg2-binary
+psycopg2==2.9.3
 asyncpg
 databases[postgresql]
 SQLAlchemy

--- a/app/websocket/connection_manager.py
+++ b/app/websocket/connection_manager.py
@@ -1,0 +1,21 @@
+from fastapi import WebSocket
+
+
+class ConnectionManager:
+    def __init__(self):
+        self.active_connections = {}
+
+    async def connect(self, id: str, websocket: WebSocket):
+        await websocket.accept()
+        self.active_connections[id] = websocket
+
+    def disconnect(self, id: str):
+        if id in self.active_connections:
+            del self.active_connections[id]
+
+    async def send_personal_message(self, id: str, message):
+        if id in self.active_connections:
+            await self.active_connections[id].send_json(message)
+
+
+connection_manager = ConnectionManager()


### PR DESCRIPTION
# ErgoAuth Implementation
## Schemas
```python
class LoginRequest(BaseModel):
    address: str


class LoginRequestWebResponse(BaseModel):
    address: str
    signingMessage: str
    tokenUrl: str


class LoginRequestMobileResponse(BaseModel):
    address: str
    verificationId: str
    signingRequestUrl: str


class ErgoAuthRequest(BaseModel):
    address: str
    signingMessage: str
    sigmaBoolean: str
    userMessage: str = "sign this message using your wallet to approve authenticate paideia.im"
    messageSeverity: str = "INFORMATION"
    replyTo: str


class ErgoAuthResponse(BaseModel):
    signedMessage: str
    proof: str
```

## API endpoints
- ### POST `("/auth/login", response_model=LoginRequestWebResponse, request_model=LoginRequest)`
generates signing message that needs to be signed by nautilus or any other browser based wallet

- ### POST `("/auth/token/{request_id}", request_model=ErgoAuthResponse)`
checks the signed message and proof and returns a jwt token  on verification

- ### POST `("auth/login/mobile", response_model=LoginRequestMobileResponse, request_model=LoginRequest)`
generate signing message that needs to be signed by ergo wallet mobile app and return the url for signing request

- ### GET `("auth/signing_request/{request_id}", response_model=ErgoAuthRequest)`
returns the ErgoAuthRequest json object for the given request id

- ### POST `("auth/verify/{request_id}", request_model=ErgoAuthResponse)`
verifies the signed message and proof given by the wallet and triggers the websocket endpoint

- ### POST `("auth/signup" response_model=User, request_model=UserSignUp) [deprecated]`
create a user with unique primary address
Note: this endpoint will be updated based on how we configure user sign ups for paideia

## WebSocket Listeners
- ### WebSocket `("auth/ws/{request_id}")`
returns a jwt_token or failure message on trigger

## Issues:
- https://github.com/ergo-pad/ergopad-api/issues/340