### PR TITLE
:update: make user profiles dao specific

### DIFF
--- a/app/api/users.py
+++ b/app/api/users.py
@@ -14,6 +14,7 @@ from db.crud.users import (
     get_user_address_config,
     get_user_profile,
     get_user_profile_settings,
+    create_user_dao_profile,
     edit_user_profile,
     edit_user_profile_settings,
     update_user_follower,
@@ -258,13 +259,14 @@ def verify_user_address_change(
 )
 def user_details_all(
     user_id: int,
+    dao_id: int,
     db=Depends(get_db),
 ):
     """
     Get any user details
     """
     try:
-        return get_user_profile(db, user_id)
+        return get_user_profile(db, user_id, dao_id)
     except Exception as e:
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'{str(e)}')
 
@@ -276,6 +278,7 @@ def user_details_all(
     name="users:user-profile-settings"
 )
 def user_profile_settings(
+    dao_id: int,
     db=Depends(get_db),
     user=Depends(get_current_active_user),
 ):
@@ -283,7 +286,24 @@ def user_profile_settings(
     Get any user profile preferences
     """
     try:
-        return get_user_profile_settings(db, user.id)
+        return get_user_profile_settings(db, user.id, dao_id)
+    except Exception as e:
+        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'{str(e)}')
+
+
+@r.post(
+    "/create_user_profile", response_model=UserDetails, response_model_exclude_none=True, name="users:create-details"
+)
+def create_user_profile(
+    dao_id: int,
+    db=Depends(get_db),
+    current_user=Depends(get_current_active_user),
+):
+    """
+    Create new dao specific user profile
+    """
+    try:
+        return create_user_dao_profile(db, current_user.id, dao_id)
     except Exception as e:
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'{str(e)}')
 
@@ -293,6 +313,7 @@ def user_profile_settings(
 )
 def edit_user_details(
     user_id: int,
+    dao_id: int,
     user_details: UpdateUserDetails,
     db=Depends(get_db),
     current_user=Depends(get_current_active_user),
@@ -303,7 +324,7 @@ def edit_user_details(
     try:
         if user_id != current_user.id:
             return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content="User not authorized")
-        return edit_user_profile(db, user_id, user_details)
+        return edit_user_profile(db, user_id, dao_id, user_details)
     except Exception as e:
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'{str(e)}')
 
@@ -312,6 +333,7 @@ def edit_user_details(
     "/profile/settings", response_model=UserProfileSettings, response_model_exclude_none=True, name="users:edit-profile-settings"
 )
 def edit_user_settings(
+    dao_id: int,
     user_settings: UpdateUserProfileSettings,
     db=Depends(get_db),
     current_user=Depends(get_current_active_user),
@@ -320,7 +342,7 @@ def edit_user_settings(
     Update existing user preferences
     """
     try:
-        return edit_user_profile_settings(db, current_user.id, user_settings)
+        return edit_user_profile_settings(db, current_user.id, dao_id, user_settings)
     except Exception as e:
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'{str(e)}')
 

--- a/app/db/models/users.py
+++ b/app/db/models/users.py
@@ -21,7 +21,8 @@ class UserDetails(Base):
     __tablename__ = "user_details"
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, unique=True)
+    user_id = Column(Integer)
+    dao_id = Column(Integer)
     name = Column(String)
     profile_img_url = Column(String)
     bio = Column(String)
@@ -42,7 +43,8 @@ class UserProfileSettings(Base):
     __tablename__ = "user_profile_settings"
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, unique=True)
+    user_id = Column(Integer)
+    dao_id = Column(Integer)
     settings = Column(JSON)
 
 

--- a/app/db/schemas/users.py
+++ b/app/db/schemas/users.py
@@ -62,6 +62,7 @@ class UpdateUserDetails(BaseModel):
 class UserDetails(UpdateUserDetails):
     id: int
     user_id: int
+    dao_id: int
     followers: t.List[int]
     following: t.List[int]
 
@@ -76,6 +77,7 @@ class UpdateUserProfileSettings(BaseModel):
 class UserProfileSettings(UpdateUserProfileSettings):
     id: int
     user_id: int
+    dao_id: int
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
## Make user profile dao specific
### Users have can have different profiles/bios at a per dao level
- API for `user_details` and `user_profile_settings` takes `?dao_id=` as query string
- NEW API endpoint `/users/create_user_profile` create dao_specific empty profile

### Search user profiles by wallet address
- allows for search by search string
- example: `users/details/search?search_string=noob` -> returns all complete or incomplete matches (name, alias, wallet_address)
```
[
  {
    "id": 10,
    "dao_id": 3,
    "alias": "admin",
    "address": "__redacted",
    "name": "noob77777"
  }
]
```

### Issue
- https://github.com/ergo-pad/paideia/issues/4